### PR TITLE
Tests+cleanup

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -9,6 +9,12 @@ git-tree-sha1 = "055eb2690182ebc31087859c3dd8598371d3ef9e"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.3"
 
+[[Crayons]]
+deps = ["Test"]
+git-tree-sha1 = "f621b8ef51fd2004c7cf157ea47f027fdeac5523"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.0.0"
+
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Jonas Asprion <jonas.asprion@gmx.ch", "Thibaut Lienart <tlienart@me.
 version = "0.1.0"
 
 [deps]
+Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,7 @@ makedocs(
         #     "Quick start"          => "man/quickstart.md",
         #     ],
         "Library" => [
+            "Public"    => "lib/public.md",
             "Internals" => "lib/internals.md",
             ],
         ], # end pages

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -1,0 +1,12 @@
+# Internal Documentation
+
+Documentation for `LiveServer.jl`'s public interface
+
+```@docs
+LiveServer.serve
+LiveServer.SimpleWatcher
+LiveServer.start
+LiveServer.stop
+LiveServer.set_callback!
+Liveserver.watch_file!
+```

--- a/src/LiveServer.jl
+++ b/src/LiveServer.jl
@@ -27,12 +27,20 @@ const BROWSER_RELOAD_SCRIPT = """
     </script>
     """
 
+const VERBOSE = Ref{Bool}(false)
 
 # "List of files being tracked by WebSocket connections"
 const WS_HTML_FILES = Dict{String,Vector{HTTP.WebSockets.WebSocket}}()
 
 include("file_watching.jl")
 include("server.jl")
+
+"""
+    verbose(b)
+
+Set the verbosity to either true (showing messages) or false (default).
+"""
+verbose(b::Bool) = (VERBOSE.x = b)
 
 """
     example()

--- a/src/file_watching.jl
+++ b/src/file_watching.jl
@@ -20,8 +20,8 @@ WatchedFile(f_path::AbstractString) = WatchedFile(f_path, mtime(f_path))
 """
     has_changed(wf::WatchedFile)
 
-Check if a `WatchedFile` has changed. Returns -1 if the file does not exist, 0 if it does
-exist but has not changed, and 1 if it has changed.
+Check if a `WatchedFile` has changed. Returns -1 if the file does not exist, 0 if it does exist but
+has not changed, and 1 if it has changed.
 """
 function has_changed(wf::WatchedFile)
     isfile(wf.path) || return -1
@@ -39,20 +39,20 @@ set_unchanged!(wf::WatchedFile) = wf.mtime = mtime(wf.path)
 """
     SimpleWatcher([callback]; sleeptime::Float64=0.1)
 
-A simple file watcher. You can specify a callback function, receiving the
-path of each file that has changed as an `AbstractString`, at construction or later
-by the API function described below. The `sleeptime` is the time waited
-between to runs of the loop looking for changed files, it is constrained to be
-at least 0.05s.
+A simple file watcher. You can specify a callback function, receiving the path of each file that
+has changed as an `AbstractString`, at construction or later by the API function described below.
+The `sleeptime` is the time waited between to runs of the loop looking for changed files, it is
+constrained to be at least 0.05s.
 
 # API functions
+
 It follows an overview on all API functions. Here, `w` is a `SimpleWatcher`.
-The main API functions that are used by the live server, and thus are to
-be overloaded by external file watchers and exported by default:
+The main API functions that are used by the live server, and thus are to be overloaded by external
+file watchers and exported by default:
 
 - `start(w)`: start the watcher
-- `stop(w)`: stop the watcher; preserves the list of watched files and new files
-   can still be added using `watch_file!`
+- `stop(w)`: stop the watcher; preserves the list of watched files and new files can still be added
+using `watch_file!`
 - `set_callback!(w, callback::Function)`: set callback to be executed upon file changes
 - `watch_file!(w, filepath::AbstractString)`: add file to be watched
 

--- a/src/file_watching.jl
+++ b/src/file_watching.jl
@@ -36,7 +36,13 @@ Set the current state of a `WatchedFile` as unchanged"
 set_unchanged!(wf::WatchedFile) = wf.mtime = mtime(wf.path)
 
 
+"""
+    FileWatcher
+
+Abstract Type for file watching objects such as [`SimpleWatcher`](@ref).
+"""
 abstract type FileWatcher end
+
 
 """
     SimpleWatcher([callback]; sleeptime::Float64=0.1) <: FileWatcher
@@ -135,7 +141,6 @@ function file_watcher_task!(fw::FileWatcher)
                 if state == 0
                     continue
                 elseif state == 1
-                    sqrt(-1)
                     # the file has changed, set it unchanged and trigger callback
                     set_unchanged!(wf)
                     fw.callback(wf.path)

--- a/src/file_watching.jl
+++ b/src/file_watching.jl
@@ -93,22 +93,21 @@ stop(w)
 ```
 """
 mutable struct SimpleWatcher
-    "Callback function executed upon file changes, receives a file path as `AbstractString`"
-    callback::Union{Nothing,Function}
-
-    "The asynchronous file-watching task"
-    task::Union{Nothing,Task}
-
-    "Sleep time between checks for changes on watched files"
-    sleeptime::Float64
-
-    "List of files being watched"
-    filelist::Vector{WatchedFile}
-
-    "Default constructor"
-    SimpleWatcher(callback::Union{Nothing,Function}=nothing; sleeptime::Float64=0.1) =
-        new(callback,nothing,max(0.05,sleeptime),Vector{WatchedFile}())
+    callback::Union{Nothing,Function} # callback function triggered upon file change
+    task::Union{Nothing,Task}         # asynchronous file-watching task
+    sleeptime::Float64                # sleep-time before checking for file changes
+    filelist::Vector{WatchedFile}     # list of files being watched
 end
+
+"""
+    SimpleWatcher([callback]; sleeptime)
+
+Instantiate a new `SimpleWatcher` with an optional callback triggered upon file change.
+The `sleeptime` argument can be used to determine how often to check for file change (default is
+every 0.1 second and minimum is 0.05).
+"""
+SimpleWatcher(callback::Union{Nothing,Function}=nothing; sleeptime::Float64=0.1) =
+    SimpleWatcher(callback, nothing, max(0.05, sleeptime), Vector{WatchedFile}())
 
 
 """

--- a/src/server.jl
+++ b/src/server.jl
@@ -19,18 +19,18 @@ end
 """
     file_changed_callback(filepath::AbstractString)
 
-Function reacting to the change of files. Is set as callback for the
-file watcher.
+Function reacting to the change of a file `filepath`. Is set as callback for the file watcher.
 """
 function file_changed_callback(filepath::AbstractString)
     println("ℹ [LiveUpdater]: Reacting to change in file '$filepath'...")
-    if lowercase(splitext(filepath)[2]) ∈ (".html", ".htm")
+    if endswith(filepath, ".html")
         # if html file, update viewers of this file only
         update_and_close_viewers!(WS_HTML_FILES[filepath])
     else
         # otherwise (e.g. modification to a CSS file), update all viewers
         foreach(update_and_close_viewers!, values(WS_HTML_FILES))
     end
+    return nothing
 end
 
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -22,7 +22,7 @@ end
 Function reacting to the change of a file `filepath`. Is set as callback for the file watcher.
 """
 function file_changed_callback(filepath::AbstractString)
-    println("ℹ [LiveUpdater]: Reacting to change in file '$filepath'...")
+    VERBOSE.x && println("ℹ [LiveUpdater]: Reacting to change in file '$filepath'...")
     if endswith(filepath, ".html")
         # if html file, update viewers of this file only
         update_and_close_viewers!(WS_HTML_FILES[filepath])
@@ -187,10 +187,11 @@ function serve(filewatcher=SimpleWatcher(); port::Int=8000)
     # wait until user interrupts the LiveServer (using CTRL+C).
     try while true
         sleep(0.1)
+        filewatcher.isok || throw(InterruptException)
         end
     catch err
         if isa(err, InterruptException)
-            println("\n⋮ shutting down LiveServer")
+            VERBOSE.x && println("\n⋮ shutting down LiveServer")
 
             stop(filewatcher)
             # close any remaining websockets
@@ -200,7 +201,7 @@ function serve(filewatcher=SimpleWatcher(); port::Int=8000)
             empty!(WS_HTML_FILES)
 
             close(server) # shut down server
-            println("\n✓ LiveServer shut down.")
+            VERBOSE.x && println("\n✓ LiveServer shut down.")
         else
             throw(err)
         end

--- a/src/server.jl
+++ b/src/server.jl
@@ -187,7 +187,7 @@ function serve(filewatcher=SimpleWatcher(); port::Int=8000)
     # wait until user interrupts the LiveServer (using CTRL+C).
     try while true
         sleep(0.1)
-        filewatcher.isok || throw(InterruptException)
+        (filewatcher.status == :interrupted) && throw(InterruptException())
         end
     catch err
         if isa(err, InterruptException)

--- a/test/file_watching.jl
+++ b/test/file_watching.jl
@@ -37,13 +37,13 @@ end
     @test sw.callback === nothing
     @test sw.task === nothing
     @test sw.sleeptime == 0.1
-    @test isempty(sw.filelist)
-    @test eltype(sw.filelist) == LS.WatchedFile
+    @test isempty(sw.watchedfiles)
+    @test eltype(sw.watchedfiles) == LS.WatchedFile
 
     @test sw1.sleeptime == 0.05 # via the clamping
     @test sw1.callback(2) == 2 # identity function
     @test sw1.callback("blah") == "blah"
-    @test isempty(sw1.filelist)
+    @test isempty(sw1.watchedfiles)
     @test sw1.task === nothing
 end
 
@@ -54,8 +54,8 @@ end
     LS.watch_file!(sw, file1)
     LS.watch_file!(sw, file2)
 
-    @test sw.filelist[1].path == file1
-    @test sw.filelist[2].path == file2
+    @test sw.watchedfiles[1].path == file1
+    @test sw.watchedfiles[2].path == file2
 
     # is_file_watched
 

--- a/test/file_watching.jl
+++ b/test/file_watching.jl
@@ -57,10 +57,10 @@ end
     @test sw.watchedfiles[1].path == file1
     @test sw.watchedfiles[2].path == file2
 
-    # is_file_watched
+    # is_watched
 
-    @test LS.is_file_watched(sw, file1)
-    @test LS.is_file_watched(sw, file2)
+    @test LS.is_watched(sw, file1)
+    @test LS.is_watched(sw, file2)
 
     # isrunning?
     @test !LS.isrunning(sw)

--- a/test/file_watching.jl
+++ b/test/file_watching.jl
@@ -89,7 +89,7 @@ end
     # function will fail on a string
     println("\n⚠ Deliberately causing an error to be displayed and handled...\n")
     write(file1, "modif")
-    sleep(0.2)
+    sleep(0.2) # needs to be sufficient to give time for propagation.
     @test sw.status == :interrupted
 
     #

--- a/test/file_watching.jl
+++ b/test/file_watching.jl
@@ -51,8 +51,8 @@ end
 @testset "watch_file routines         " begin
     sw = LS.SimpleWatcher(identity)
 
-    LS.watch_file(sw, file1)
-    LS.watch_file(sw, file2)
+    LS.watch_file!(sw, file1)
+    LS.watch_file!(sw, file2)
 
     @test sw.filelist[1].path == file1
     @test sw.filelist[2].path == file2

--- a/test/file_watching.jl
+++ b/test/file_watching.jl
@@ -87,9 +87,10 @@ end
 
     # causing a modification will generate an error because the callback
     # function will fail on a string
+    println("\n⚠ Deliberately causing an error to be displayed and handled...\n")
     write(file1, "modif")
-    sleep(0.1)
-    @test !sw.isok
+    sleep(0.2)
+    @test sw.status == :interrupted
 
     #
     # deleting files

--- a/test/file_watching.jl
+++ b/test/file_watching.jl
@@ -87,7 +87,8 @@ end
 
     # causing a modification will generate an error because the callback
     # function will fail on a string
-    println("\n⚠ Deliberately causing an error to be displayed and handled...\n")
+    cray = Crayon(foreground=:cyan, bold=true)
+    println(cray, "\n⚠ Deliberately causing an error to be displayed and handled...\n")
     write(file1, "modif")
     sleep(0.2) # needs to be sufficient to give time for propagation.
     @test sw.status == :interrupted

--- a/test/file_watching.jl
+++ b/test/file_watching.jl
@@ -90,7 +90,7 @@ end
     cray = Crayon(foreground=:cyan, bold=true)
     println(cray, "\n⚠ Deliberately causing an error to be displayed and handled...\n")
     write(file1, "modif")
-    sleep(0.2) # needs to be sufficient to give time for propagation.
+    sleep(0.25) # needs to be sufficient to give time for propagation.
     @test sw.status == :interrupted
 
     #
@@ -111,7 +111,7 @@ end
     start(sw)
 
     rm(file3)
-    sleep(0.1)
+    sleep(0.25) # needs to be sufficient to give time for propagation.
 
     # file3 was deleted
     @test length(sw.watchedfiles) == 2

--- a/test/file_watching.jl
+++ b/test/file_watching.jl
@@ -19,12 +19,12 @@ write(file2, ".")
     t1 = time()
     sleep(0.01)
     write(file1, "hello")
-    @test LS.has_changed(wf1)
-    @test !LS.has_changed(wf2)
+    @test LS.has_changed(wf1) == 1
+    @test LS.has_changed(wf2) == 0
 
     # Set state as unchanged
     LS.set_unchanged!(wf1)
-    @test !LS.has_changed(wf1)
+    @test LS.has_changed(wf1) == 0
     @test wf1.mtime > t1
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using LiveServer, Test
+using LiveServer, Test, Crayons
 const LS = LiveServer
 
 include("file_watching.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using LiveServer, Test
-
 const LS = LiveServer
 
 include("file_watching.jl")

--- a/test/server.jl
+++ b/test/server.jl
@@ -1,13 +1,13 @@
-@testset "Get File                    " begin
+@testset "Miscellaneous               " begin
 
+    # requested path --> a filesystem path
     bk = pwd()
-    cd(splitdir(splitdir(pathof(LiveServer))[1])[1])
-
+    cd(dirname(dirname(pathof(LiveServer))))
     req = "foo"
     @test LS.get_fs_path(req) == ""
-
     req = "/test/dummies/index.html"
     @test LS.get_fs_path(req) == "./test/dummies/index.html"
-
     cd(bk)
+
+    
 end


### PR DESCRIPTION
This PR looks primarily at `file_watching.jl` and attempts to generally clean things up, remove unnecessary stuff, and have a better handling of interruption #15 ; it also adds control for verbosity #16 

The changes are otherwise not major (i.e. the structure and spirit is still identical) so I'll merge upon tests passing. If there are stuff that I do that you don't like let me know, I'll fix and will try not to do that again 😉 