### PR TITLE
Monkey patching HTTP

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,10 +39,8 @@ version = "0.22.2"
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[HTTP]]
-deps = ["Base64", "Dates", "Distributed", "IniFile", "JSON", "MbedTLS", "Sockets", "Test"]
-git-tree-sha1 = "4a2beedabe7e627e8cea0d3db5a82d1222897dac"
-repo-rev = "master"
-repo-url = "https://github.com/tlienart/HTTP.jl"
+deps = ["Base64", "Dates", "Distributed", "IniFile", "MbedTLS", "Random", "Sockets", "Test"]
+git-tree-sha1 = "25db0e3f27bd5715814ca7e4ad22025fdcf5cc6e"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 version = "0.8.0"
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,8 @@ The package is currently unregistered.
 To install it in Julia ≥ 1.0, use the package manager with
 
 ```julia-repl
-pkg> add https://github.com/tlienart/HTTP.jl
 pkg> add https://github.com/asprionj/LiveServer.jl
 ```
-
-**NOTE**: the first line will install our patched fork of `HTTP.jl` which helps with proper server shutdown; see also [this issue](https://github.com/asprionj/LiveServer.jl/issues/48).
 
 ## Usage
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,11 +11,8 @@ The package is currently un-registered.
 In Julia ≥ 1.0, you can add it using the Package Manager writing
 
 ```julia-repl
-pkg> add https://github.com/tlienart/HTTP.jl
 pkg> add https://github.com/asprionj/LiveServer.jl
 ```
-
-**NOTE**: the first line will install our patched fork of `HTTP.jl` which helps with proper server shutdown; see also [this issue](https://github.com/asprionj/LiveServer.jl/issues/48).
 
 ## Usage
 

--- a/src/LiveServer.jl
+++ b/src/LiveServer.jl
@@ -2,9 +2,7 @@ module LiveServer
 
 # from stdlib
 using Sockets
-# the only dependency. NOTE: we use our own patched branch of HTTP.jl for the moment
-# to guarantee that all tasks are properly shut down upon closing the server see
-# https://github.com/JuliaWeb/HTTP.jl/issues/405
+# the only dependency (see the patch in http_patch.jl)
 using HTTP
 
 export serve, servedocs
@@ -23,6 +21,11 @@ const CONTENT_DIR = Ref{String}("")
 const WS_VIEWERS = Dict{String,Vector{HTTP.WebSockets.WebSocket}}()
 # keep track of whether an interruption happened while processing a websocket
 const WS_INTERRUPT = Base.Ref{Bool}(false)
+
+#
+# HTTP patch
+#
+include("http_patch.jl")
 
 #
 # Core

--- a/src/http_patch.jl
+++ b/src/http_patch.jl
@@ -1,0 +1,131 @@
+#=
+This is a patch for issue #405 (https://github.com/JuliaWeb/HTTP.jl/issues/405) which allows
+the proper closing of @async tasks that are launched by the listen loop of HTTP. Without this
+patch these tasks may live on which may cause bugs further downstream.
+This patch is "not ideal"; a better solution would be to cleanly keep track of all tasks. The
+better solution will likely be implemented in the future but in the mean time this patch fixes the
+bug and is simple. It will be removed when the bug is fixed proper upstream.
+
+This concerns only `src/Servers.jl` and specifically `listenloop`; the difference can be seen in
+https://github.com/JuliaWeb/HTTP.jl/pull/406
+=#
+
+using HTTP.IOExtras
+using HTTP.Streams
+using HTTP.Messages
+#using HTTP.Parsers
+using HTTP.ConnectionPool
+
+import HTTP.Servers.listenloop
+
+function listenloop(f::Function, server, tcpisvalid, connection_count,
+                    reuse_limit, readtimeout, verbose)
+    count = 1
+    while isopen(server)
+        try
+            io = accept(server)
+
+            if !tcpisvalid(io)
+                verbose && @info "Accept-Reject:  $io"
+                close(io)
+                continue
+            end
+            connection_count[] += 1
+            conn = Connection(io)
+            conn.host, conn.port = server.hostname, server.hostport
+            let io=io, count=count
+                @async try
+                    verbose && @info "Accept ($count):  $conn"
+                    handle_connection(f, conn, reuse_limit, readtimeout, server)
+                    verbose && @info "Closed ($count):  $conn"
+                catch e
+                    if e isa Base.IOError && e.code == -54
+                        verbose && @warn "connection reset by peer (ECONNRESET)"
+                    else
+                        @error exception=(e, stacktrace(catch_backtrace()))
+                    end
+                finally
+                    connection_count[] -= 1
+                    close(io)
+                    verbose && @info "Closed ($count):  $conn"
+                end
+            end
+        catch e
+            if e isa InterruptException
+                @warn "Interrupted: listen($server)"
+                close(server)
+                break
+            else
+                rethrow(e)
+            end
+        end
+        count += 1
+    end
+    return
+end
+
+function handle_connection(f, c::Connection, reuse_limit, readtimeout, server)
+    wait_for_timeout = Ref{Bool}(true)
+    if readtimeout > 0
+        @async check_readtimeout(c, readtimeout, wait_for_timeout)
+    end
+    try
+        count = 0
+        while isopen(c)
+            if isopen(server)
+                handle_transaction(f, Transaction(c), server;
+                                   final_transaction=(count == reuse_limit))
+                count += 1
+            else
+                close(c)
+            end
+        end
+    finally
+        wait_for_timeout[] = false
+    end
+    return
+end
+
+function handle_transaction(f, t::Transaction, server; final_transaction::Bool=false)
+    request = Request()
+    http = Stream(request, t)
+
+    try
+        startread(http)
+    catch e
+        if e isa EOFError && isempty(request.method)
+            return
+        elseif e isa ParseError
+            status = e.code == :HEADER_SIZE_EXCEEDS_LIMIT  ? 413 : 400
+            write(t, Response(status, body = string(e.code)))
+            close(t)
+            return
+        else
+            rethrow(e)
+        end
+    end
+
+    request.response.status = 200
+    if final_transaction || hasheader(request, "Connection", "close")
+        setheader(request.response, "Connection" => "close")
+    end
+
+    @async try
+        if isopen(server)
+            f(http)
+            closeread(http)
+            closewrite(http)
+        end
+    catch e
+        @error "error handling request" exception=(e, stacktrace(catch_backtrace()))
+        if isopen(http) && !iswritable(http)
+            http.message.response.status = 500
+            startwrite(http)
+            write(http, sprint(showerror, e))
+        end
+        final_transaction = true
+    finally
+        final_transaction && close(t.c.io)
+    end
+    return
+end


### PR DESCRIPTION
Ok unfortunately to make sure that the user uses our patch of HTTP, we have to monkey patch (i.e. write the code in our package explicitly). The TOML is not enough if the user already has HTTP on their system (they'd have to overwrite it and that's not desirable).

Anyway so this PR adds my patch, it works and tests pass. Of course it doesn't make sense to write tests for this bit since it's effectively already tested in HTTP.jl (it's also quite painful to test due to the flurry of asyncs everywhere) so unfortunately it will bring the code coverage down to ~80% but it doesn't really matter :shrug:.