### PR TITLE
URI-decode paths to search for

### DIFF
--- a/test/dummies/résumé/index.html
+++ b/test/dummies/résumé/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    Content
+  </body>
+</html>

--- a/test/server.jl
+++ b/test/server.jl
@@ -6,6 +6,8 @@
     @test LS.get_fs_path(req) == ""
     req = "/test/dummies/index.html"
     @test LS.get_fs_path(req) == "test/dummies/index.html"
+    req = "/test/dummies/r%C3%A9sum%C3%A9/"
+    @test LS.get_fs_path(req) == "test/dummies/résumé/index.html"
     cd(bk)
 end
 


### PR DESCRIPTION
First of all, thank you for making this package!

While porting my website to JuDoc, I noticed that my `résumé/index.html` page was returning a 404. I added a `unescapeuri` here which I believe should address the problem.

I also changed the browser-sync to apply based on MIME type instead of only the `html` extension, but this is an unrelated change. I can separate it out if preferred.