### PR TITLE
Add the `inject_browser_reload_script` keyword argument

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LiveServer"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 authors = ["Jonas Asprion <jonas.asprion@gmx.ch", "Thibaut Lienart <tlienart@me.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"


### PR DESCRIPTION
The "browser reload script" that LiveServer automatically inserts into HTML sometimes breaks my particular use case.

This pull request adds the `inject_browser_reload_script` keyword argument that allows the user to disable this feature.

cc: @asprionj 
cc: @tlienart 