### PR TITLE
cleaning up loggingextras

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "LiveServer"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 authors = ["Jonas Asprion <jonas.asprion@gmx.ch", "Thibaut Lienart <tlienart@me.com>"]
-version = "1.2.6"
+version = "1.2.7"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 MIMEs = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -13,4 +14,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 HTTP = "1"
 MIMEs = "0.1"
+LoggingExtras = "1"
 julia = "1.6"

--- a/src/LiveServer.jl
+++ b/src/LiveServer.jl
@@ -5,6 +5,7 @@ using Base.Filesystem
 using Base.Threads: @spawn
 
 using HTTP
+using LoggingExtras
 
 export serve, servedocs
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -52,7 +52,6 @@ function update_and_close_viewers!(
     @sync for wsᵢ in ws_to_update_and_close
         isopen(wsᵢ.io) && @spawn begin
             try
-                redirect_stderr()
                 HTTP.WebSockets.send(wsᵢ, "update")
             catch
             end
@@ -64,7 +63,6 @@ function update_and_close_viewers!(
     @sync for wsi in ws_to_update_and_close
         isopen(wsi.io) && @spawn begin
             try
-                redirect_stderr()
                 wsi.writeclosed = wsi.readclosed = true
                 close(wsi.io)
             catch
@@ -618,6 +616,15 @@ current directory. (See also [`example`](@ref) for an example folder).
         )
     end
 
+    old_logger = global_logger()
+    old_stderr = stderr
+    global_logger(
+        EarlyFilteredLogger(
+            log -> log._module !== HTTP.Servers,
+            global_logger()
+        )
+    )
+
     server, port = get_server(host, port, req_handler)
     host_str     = ifelse(host == string(Sockets.localhost), "localhost", host)
     url          = "http://$host_str:$port"
@@ -676,6 +683,13 @@ current directory. (See also [`example`](@ref) for an example folder).
         reset_ws_interrupt()
         println("✓")
     end
+    
+    # given that LiveServer is interrupted via an InterruptException, we have
+    # to be extra careful that things are back as they were before, otherwise
+    # there's a high risk of the disgusting broken pipe error...
+    redirect_stderr(old_stderr)
+    global_logger(old_logger)
+
     return nothing
 end
 
@@ -697,7 +711,6 @@ function get_server(
     incr >= 10 && @error "couldn't find a free port in $incr tries"
     try
         server = HTTP.listen!(host, port; readtimeout=0, verbose=-1) do http::HTTP.Stream
-            redirect_stderr()
             if HTTP.WebSockets.isupgrade(http.message)
                 # upgrade to websocket and add to list of viewers and keep open
                 # until written to


### PR DESCRIPTION
Turns out there were some stray `redirect_stderr()` so bringing back (...) the loggingextras stuff, seems to be better now including with stress on IO. Let's see...